### PR TITLE
Update/across session creds

### DIFF
--- a/MemoryNonceStore.js
+++ b/MemoryNonceStore.js
@@ -32,6 +32,7 @@ class MemoryNonceStore {
 
   /**
    * Checks if a new nonce is valid, mark it as used
+   * @author Gabe Abrams
    * @param {string} nonce - OAuth nonce
    * @param {string} timestamp - OAuth timestamp
    * @return Promise that resolves if nonce is valid, rejects with error if
@@ -94,6 +95,7 @@ class MemoryNonceStore {
   /**
    * Performs a maintenance rotation: nonces are moved from
    *   isUsedPrime => isUsedSecondary and nonces in isUsedSecondary are deleted
+   * @author Gabe Abrams
    */
   _rotate() {
     this.isUsedMutex.lock(() => {

--- a/Validator.js
+++ b/Validator.js
@@ -1,13 +1,16 @@
+// Import libraries
 const oauth = require('oauth-signature');
 const clone = require('fast-clone');
 const urlLib = require('url');
 
+// Import local modules
 const MemoryNonceStore = require('./MemoryNonceStore');
 
 /* LTI launch validator */
 class Validator {
   /**
    * Creates a new Validator
+   * @author Gabe Abrams
    * @param {string} consumer_key - an LTI consumer id to compare against during
    *   launch validation
    * @param {string} consumer_secret - an LTI consumer secret to use for
@@ -19,7 +22,7 @@ class Validator {
   constructor(config = {}) {
     this.nonceStore = config.nonceStore || new MemoryNonceStore();
 
-    // Consumer credentials
+    // Verify and save consumer credentials
     if (!config.consumer_secret) {
       throw new Error('Validator requires consumer_secret');
     }
@@ -32,6 +35,7 @@ class Validator {
 
   /**
    * Checks if an LTI launch request is valid
+   * @author Gabe Abrams
    * @param {object} req - Express request object to verify
    * @return {Promise} promise that resolves if valid, rejects if invalid
    */
@@ -56,6 +60,7 @@ class Validator {
 
   /**
    * Checks if a nonce is valid
+   * @author Gabe Abrams
    * @param {object} req - Express request object to verify
    * @return Promise that resolves if valid, rejects if invalid
    */
@@ -68,6 +73,7 @@ class Validator {
 
   /**
    * Checks if an oauth_signature is valid
+   * @author Gabe Abrams
    * @param {object} req - Express request object to verify
    * @return boolean, true if req.body.oauth_signature is valid
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-lti",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-lti",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "description": "LTI launch validator for IMS-LTI standard launches.",
   "main": "index.js",
   "scripts": {

--- a/parseLaunch.js
+++ b/parseLaunch.js
@@ -168,9 +168,7 @@ module.exports = (launchBodyOrig, req) => {
   ) {
     // NOTE: Keep these values up-to-date with all the session variables added
     // by caccl-authorizer
-    req.session.accessToken = undefined;
-    req.session.refreshToken = undefined;
-    req.session.accessTokenExpiry = undefined;
+    req.accessToken = undefined;
     req.session.authorized = undefined;
     req.session.authFailed = undefined;
     req.session.authFailureReason = undefined;

--- a/parseLaunch.js
+++ b/parseLaunch.js
@@ -1,5 +1,6 @@
 /**
  * Returns parsed value of val if val is truthy, otherwise just returns val
+ * @author Gabe Abrams
  * @param val - value to parse if truthy
  * @return value (parsed as int if truthy)
  */
@@ -12,6 +13,7 @@ const parseIntIfTruthy = (val) => {
 
 /**
  * Returns split array of val if val is truthy, otherwise just returns val
+ * @author Gabe Abrams
  * @param val - value to split if truthy
  * @return value (split on "," if truthy)
  */
@@ -35,6 +37,14 @@ const CANVAS_CUSTOM_PARAMS = [
   'custom_canvas_assignment_id',
 ];
 
+/**
+ * Parses an LTI launch body and saves results to the session under
+ *   req.session.launched (set to true) and req.session.launchInfo (contains
+ *   all launch information...see /docs/LaunchInfo.md for more info)
+ * @author Gabe Abrams
+ * @param {object} launchBody - the body of the launch request
+ * @param {Express Request} req - express request instance
+ */
 module.exports = (launchBodyOrig, req) => {
   const launchBody = launchBodyOrig || req.body;
 


### PR DESCRIPTION
This is part of a large across-caccl change to switch access tokens from being in the session to being in the tokenStore. This will solve token race conditions between sessions of the same user and will make it possible for users to be logged into the same app on different machines without causing issues with Canvas, though this does make it possible for users to get closer to throttling limits.